### PR TITLE
chore: correct initializeAuth import comment

### DIFF
--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -3,8 +3,8 @@ import { initializeApp } from "firebase/app";
 import {
   getAuth,
   getReactNativePersistence,
-  GoogleAuthProvider,
-  initializeAuth, // Import GoogleAuthProvider
+  GoogleAuthProvider, // Import GoogleAuthProvider
+  initializeAuth, // Import initializeAuth
   sendEmailVerification, // Import sendEmailVerification
 } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";


### PR DESCRIPTION
## Summary
- fix misplaced GoogleAuthProvider comment and document initializeAuth import

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: React Hook rule errors in app/(tabs)/notifications.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68af0cdf42d4832086499a4df111d785