### PR TITLE
refactor: use userId for friend suggestions

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -49,7 +49,7 @@ interface Professional {
 }
 
 interface SuggestedFriend {
-  id: string;
+  userId: string;
   name?: string;
   photoURL?: string | null;
 }
@@ -455,18 +455,18 @@ const HomeScreen = () => {
           <FlatList
             data={suggestedFriends}
             horizontal
-            keyExtractor={(item) => item.id}
+            keyExtractor={(item) => item.userId}
             showsHorizontalScrollIndicator={false}
             renderItem={({ item }) => (
               <TouchableOpacity
-                onPress={() => router.push({ pathname: "../friend-profile", params: { friendId: item.id } })}
+                onPress={() => router.push({ pathname: "../friend-profile", params: { friendId: item.userId } })}
                 style={{ marginHorizontal: 10, alignItems: "center" }}
               >
                 <UserAvatar photoURL={item.photoURL} name={item.name} size={60} />
                 <Text numberOfLines={1} style={{ maxWidth: 100 }}>{item.name}</Text>
                 <TouchableOpacity
                   onPress={async () => {
-                    await addFriend(user!.uid, item.id);
+                    await addFriend(user!.uid, item.userId);
                     const updated = await getSuggestedFriends(user!.uid);
                     setSuggestedFriends(updated);
                     Alert.alert("Amigo adicionado!", "Vocês agora estão conectados.");

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -209,10 +209,10 @@ export async function getSuggestedFriends(userId: string): Promise<UserProfile[]
 
   const querySnapshot = await getDocs(usersRef);
   return querySnapshot.docs
-    .map(doc => ({ id: doc.id, ...doc.data() } as UserProfile))
-    .filter(profile => 
-      profile.id !== userId && // Corrigido para usar 'id' em vez de 'userId'
-      !currentFriends.includes(profile.id) // Certifique-se de usar 'id' aqui também
+    .map(doc => ({ userId: doc.id, ...doc.data() } as UserProfile))
+    .filter(profile =>
+      profile.userId !== userId &&
+      !currentFriends.includes(profile.userId)
     );
 }
 


### PR DESCRIPTION
## Summary
- return friend suggestions keyed by userId instead of a synthetic id
- update home screen to consume userId-based suggestions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React Hook "useState" is called in function "renderItem" that is neither a React function component nor a custom React Hook function)*

------
https://chatgpt.com/codex/tasks/task_e_68af1229e0b0832085f6055fbc684aa0