### PR TITLE
feat: add Google Sign-In configuration

### DIFF
--- a/GoogleService-Info.plist
+++ b/GoogleService-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CLIENT_ID</key>
+    <string>REPLACE_WITH_IOS_CLIENT_ID</string>
+    <key>REVERSED_CLIENT_ID</key>
+    <string>REPLACE_WITH_REVERSED_CLIENT_ID</string>
+    <key>API_KEY</key>
+    <string>REPLACE_WITH_API_KEY</string>
+    <key>GCM_SENDER_ID</key>
+    <string>REPLACE_WITH_GCM_SENDER_ID</string>
+    <key>PLIST_VERSION</key>
+    <string>1</string>
+    <key>BUNDLE_ID</key>
+    <string>com.diegocruzalves.indicaai</string>
+    <key>PROJECT_ID</key>
+    <string>REPLACE_WITH_PROJECT_ID</string>
+    <key>STORAGE_BUCKET</key>
+    <string>REPLACE_WITH_STORAGE_BUCKET</string>
+</dict>
+</plist>

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -175,3 +175,5 @@ dependencies {
         implementation jscFlavor
     }
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     classpath('com.android.tools.build:gradle')
     classpath('com.facebook.react:react-native-gradle-plugin')
     classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
+    classpath('com.google.gms:google-services:4.4.2')
   }
 }
 

--- a/app.json
+++ b/app.json
@@ -12,7 +12,8 @@
       "supportsTablet": true,
       "runtimeVersion": {
         "policy": "appVersion"
-      }
+      },
+      "googleServicesFile": "./GoogleService-Info.plist"
     },
     "android": {
       "adaptiveIcon": {
@@ -21,7 +22,8 @@
       },
       "edgeToEdgeEnabled": true,
       "package": "com.diegocruzalves.indicaai",
-      "runtimeVersion": "1.0.0"
+      "runtimeVersion": "1.0.0",
+      "googleServicesFile": "./google-services.json"
     },
     "web": {
       "bundler": "metro",
@@ -39,7 +41,8 @@
           "backgroundColor": "#ffffff"
         }
       ],
-      "expo-web-browser"
+      "expo-web-browser",
+      "@react-native-google-signin/google-signin"
     ],
     "experiments": {
       "typedRoutes": true

--- a/google-services.json
+++ b/google-services.json
@@ -1,0 +1,34 @@
+{
+  "project_info": {
+    "project_number": "REPLACE_WITH_PROJECT_NUMBER",
+    "project_id": "REPLACE_WITH_PROJECT_ID",
+    "storage_bucket": "REPLACE_WITH_STORAGE_BUCKET"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "REPLACE_WITH_APP_ID",
+        "android_client_info": {
+          "package_name": "com.diegocruzalves.indicaai"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "REPLACE_WITH_ANDROID_CLIENT_ID",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "REPLACE_WITH_API_KEY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary
- configure Expo for Google Sign-In
- add placeholder Google service config files
- enable Google services plugin in Android build files

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and react-hooks/exhaustive-deps)*
- `npm run android` *(fails: Failed to resolve the Android SDK path. Default install location not found: /root/Android/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68af3dad33648320af97d6e7622086b5