### PR TITLE
feat: add form validation using react hook form

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "react-hook-form": "^7.51.3",
+    "yup": "^1.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add react-hook-form and yup dependencies
- use useForm with Yup schema to validate login
- show field-level validation errors instead of alerts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unable to resolve path to module 'react-hook-form')

------
https://chatgpt.com/codex/tasks/task_e_68af5bd5f5d08320b5f81e5860a44318