### PR TITLE
Add service-layer tests with firebase mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "node --experimental-test-module-mocks --experimental-strip-types --test services/**/*.test.ts"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/services/professionalService.test.ts
+++ b/services/professionalService.test.ts
@@ -1,0 +1,65 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// Sucesso: usuário recomenda profissional pela primeira vez
+test('recommendProfessional adiciona recomendação', async (t) => {
+  const docRef = {};
+  const doc = mock.fn(() => docRef);
+  const getDoc = mock.fn(async () => ({
+    exists: () => true,
+    data: () => ({ recommendedBy: [] }),
+  }));
+  const updateDoc = mock.fn(async () => {});
+  const arrayUnion = (...args) => ({ op: 'arrayUnion', args });
+  const increment = (n) => ({ op: 'increment', n });
+
+  mock.module('firebase/firestore', {
+    doc,
+    getDoc,
+    updateDoc,
+    arrayUnion,
+    increment,
+  });
+  mock.module(path.resolve(__dirname, 'firebase.ts'), { db: {} });
+
+  const { recommendProfessional } = await import('./professionalService.ts');
+
+  await recommendProfessional('prof1', 'user1');
+
+  assert.strictEqual(updateDoc.mock.callCount(), 1);
+  assert.deepStrictEqual(updateDoc.mock.calls[0].arguments[1], {
+    recommendedBy: { op: 'arrayUnion', args: ['user1'] },
+    recommendationCount: { op: 'increment', n: 1 },
+  });
+});
+
+// Erro: falha ao atualizar documento
+test('recommendProfessional registra erro quando updateDoc falha', async (t) => {
+  const doc = mock.fn(() => ({}));
+  const getDoc = mock.fn(async () => ({
+    exists: () => true,
+    data: () => ({ recommendedBy: [] }),
+  }));
+  const updateDoc = mock.fn(async () => {
+    throw new Error('firestore fail');
+  });
+  const arrayUnion = (...args) => ({ op: 'arrayUnion', args });
+  const increment = (n) => ({ op: 'increment', n });
+  const consoleError = mock.method(console, 'error');
+
+  mock.module('firebase/firestore', {
+    doc,
+    getDoc,
+    updateDoc,
+    arrayUnion,
+    increment,
+  });
+  mock.module(path.resolve(__dirname, 'firebase.ts'), { db: {} });
+
+  const { recommendProfessional } = await import('./professionalService.ts');
+
+  await recommendProfessional('prof1', 'user1');
+
+  assert.strictEqual(consoleError.mock.callCount(), 1);
+});

--- a/services/ratingService.test.ts
+++ b/services/ratingService.test.ts
@@ -1,6 +1,6 @@
-const test = require('node:test');
-const assert = require('node:assert');
-const { calculateRatingStats } = require('./ratingUtils');
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateRatingStats } from './ratingUtils.ts';
 
 test('showRating é falso com menos de 10 avaliações', () => {
   const stats = calculateRatingStats([5, 4, 3, 5, 4]);

--- a/services/userService.test.ts
+++ b/services/userService.test.ts
@@ -1,0 +1,145 @@
+const { test, mock } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// Sucesso: adiciona amizade
+test('addFriend adiciona amizade entre usuários', async (t) => {
+  mock.reset();
+  const doc = mock.fn((db, col, id) => ({ id }));
+  const getDoc = mock.fn(async () => ({ exists: () => true }));
+  const commit = mock.fn(async () => {});
+  const batch = { update: mock.fn(), commit };
+  const writeBatch = mock.fn(() => batch);
+  const arrayUnion = (id) => ({ op: 'arrayUnion', id });
+
+  mock.module('firebase/firestore', {
+    doc,
+    getDoc,
+    writeBatch,
+    arrayUnion,
+  });
+  mock.module(path.resolve(__dirname, 'firebase.ts'), { db: {} });
+
+  const { addFriend } = await import('./userService.ts');
+
+  await addFriend('u1', 'u2');
+
+  assert.strictEqual(batch.update.mock.callCount(), 2);
+  assert.strictEqual(commit.mock.callCount(), 1);
+});
+
+// Erro: usuário não encontrado
+test('addFriend lança erro se usuário inexistente', async (t) => {
+  mock.reset();
+  const doc = mock.fn((db, col, id) => ({ id }));
+  let getDocCall = 0;
+  const getDoc = mock.fn(async () => {
+    getDocCall++;
+    return getDocCall === 1
+      ? { exists: () => false }
+      : { exists: () => true };
+  });
+  const writeBatch = mock.fn();
+  const arrayUnion = (id) => ({ op: 'arrayUnion', id });
+
+  mock.module('firebase/firestore', {
+    doc,
+    getDoc,
+    writeBatch,
+    arrayUnion,
+  });
+  mock.module(path.resolve(__dirname, 'firebase.ts'), { db: {} });
+
+  const { addFriend } = await import('./userService.ts');
+
+  await assert.rejects(() => addFriend('u1', 'u2'), /Usuário não encontrado/);
+});
+
+// Utilitário para mocks de Firestore não usados no teste
+function mockFirestoreBase() {
+  return {
+    doc: mock.fn(),
+    getDoc: mock.fn(),
+    updateDoc: mock.fn(),
+    writeBatch: mock.fn(),
+    arrayUnion: mock.fn(),
+    arrayRemove: mock.fn(),
+    getDocs: mock.fn(),
+    collection: mock.fn(),
+    serverTimestamp: mock.fn(),
+    addDoc: mock.fn(),
+  };
+}
+
+// Sucesso: upload da imagem de perfil
+test('uploadProfileImage envia imagem e atualiza perfil', async (t) => {
+  mock.reset();
+  mock.module('firebase/firestore', mockFirestoreBase());
+  const ref = mock.fn((storage, path) => ({ fullPath: path }));
+  let firstCall = true;
+  const getDownloadURL = mock.fn(async () => {
+    if (firstCall) {
+      firstCall = false;
+      throw { code: 'storage/object-not-found' };
+    }
+    return 'https://url/profile.jpg';
+  });
+  const deleteObject = mock.fn(async () => undefined);
+  const uploadBytesResumable = mock.fn(() => ({
+    snapshot: { ref: 'ref' },
+    on: (state, progressCb, errorCb, successCb) => { successCb(); },
+  }));
+
+  mock.module('firebase/storage', {
+    ref,
+    getDownloadURL,
+    deleteObject,
+    uploadBytesResumable,
+  });
+  mock.module(path.resolve(__dirname, 'firebase.ts'), { db: {}, storage: {} });
+
+  const fetchMock = mock.fn(async () => ({ blob: async () => ({ size: 1 }) }));
+  mock.method(global, 'fetch', fetchMock);
+
+  const userService = await import('./userService.ts');
+  const updateUserProfileMock = mock.method(userService, 'updateUserProfile', async () => {});
+  const { uploadProfileImage } = userService;
+
+  const url = await uploadProfileImage('u1', 'http://img');
+
+  assert.strictEqual(url, 'https://url/profile.jpg');
+  assert.strictEqual(updateUserProfileMock.mock.callCount(), 1);
+  assert.deepStrictEqual(updateUserProfileMock.mock.calls[0].arguments, ['u1', { photoURL: 'https://url/profile.jpg' }]);
+});
+
+// Erro: falha no upload da imagem
+test('uploadProfileImage rejeita em caso de erro no upload', async (t) => {
+  mock.reset();
+  mock.module('firebase/firestore', mockFirestoreBase());
+  const ref = mock.fn((storage, path) => ({ fullPath: path }));
+  const getDownloadURL = mock.fn(async () => { throw { code: 'storage/object-not-found' }; });
+  const deleteObject = mock.fn(async () => {});
+  const uploadBytesResumable = mock.fn(() => ({
+    snapshot: { ref: 'ref' },
+    on: (state, progressCb, errorCb, successCb) => {
+      errorCb(new Error('upload error'));
+    },
+  }));
+
+  mock.module('firebase/storage', {
+    ref,
+    getDownloadURL,
+    deleteObject,
+    uploadBytesResumable,
+  });
+  mock.module(path.resolve(__dirname, 'firebase.ts'), { db: {}, storage: {} });
+
+  mock.method(global, 'fetch', async () => ({ blob: async () => ({ size: 1 }) }));
+
+  const userService = await import('./userService.ts');
+  const updateUserProfileMock = mock.method(userService, 'updateUserProfile', async () => {});
+  const { uploadProfileImage } = userService;
+
+  await assert.rejects(() => uploadProfileImage('u1', 'http://img'), /upload error/);
+  assert.strictEqual(updateUserProfileMock.mock.callCount(), 0);
+});


### PR DESCRIPTION
## Summary
- configure `npm test` to use Node's native runner with TypeScript stripping and module mocks
- add tests for `recommendProfessional`, `addFriend`, and `uploadProfileImage`
- convert existing ratingService test to modern `node:test`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/indicaai/services/professionalService' imported from /workspace/indicaai/services/userService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b065a5d0388320a0713cc86a57e8cb