### PR TITLE
fix: configure google login redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@
    git clone https://github.com/diegoalves1988/indicaai
    ```
 
+## 🔑 Configuração do Login com Google
+
+1. No [Google Cloud Console](https://console.cloud.google.com), em **OAuth consent screen** adicione o domínio do app em **Authorized domains**.
+2. Em **Credentials**, edite o **OAuth 2.0 Client ID** e inclua nas **Authorized redirect URIs** o valor sugerido pelo Expo (por exemplo `https://auth.expo.io/@diegocruzalves/indicaai`) ou o esquema definido no `app.json` (`indicaai://auth`).
+3. Copie o **Client ID** do tipo Web e defina-o em `app.json` dentro de `expo.extra.EXPO_PUBLIC_GOOGLE_CLIENT_ID`.
+4. Após salvar as alterações, limpe cookies/sessão do app e tente novamente o login.
+
+

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,6 @@
 import { FontAwesome } from "@expo/vector-icons";
 import * as Google from "expo-auth-session/providers/google";
+import { makeRedirectUri } from "expo-auth-session";
 import Constants from "expo-constants";
 import { useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
@@ -40,6 +41,11 @@ export default function Login() {
     console.log("extra =", Constants.expoConfig?.extra);
   }
 
+  const redirectUri = makeRedirectUri({
+    scheme: Constants.expoConfig?.scheme ?? "indicaai",
+    useProxy: true,
+  });
+
   // ---- validação com yup ----
   const schema = yup.object({
     email: yup.string().email("E-mail inválido").required("E-mail é obrigatório"),
@@ -75,6 +81,7 @@ export default function Login() {
   // ---- Google Auth (Expo Go usa 'clientId' com Web Client ID) ----
   const [, , promptAsync] = Google.useIdTokenAuthRequest({
     clientId: webClientId, // NÃO usar androidClientId/iosClientId no Expo Go
+    redirectUri,
   });
 
   const handleLogin = async ({ email, password }: FormData) => {


### PR DESCRIPTION
## Summary
- add explicit redirect URI for Google auth
- document Google login configuration

## Testing
- `npm test` *(fails: Cannot find module '/workspace/indicaai/services/firebase')*


------
https://chatgpt.com/codex/tasks/task_e_68b319b2a2588320bea168fd0b32c911